### PR TITLE
Improve dashboard demo UI

### DIFF
--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -1,0 +1,26 @@
+import { defaultNav } from "@/lib/nav-items";
+
+const content: Record<string, string> = {
+  dashboard: "Welcome to your main dashboard. A quick overview of metrics would appear here.",
+  analytics: "Charts and insights help you make informed decisions.",
+  sales: "Track revenue and monitor sales performance on this page.",
+  customers: "Manage your customer relationships and view contact history.",
+  products: "Organise your inventory and product listings.",
+  reports: "Generate detailed reports for your team.",
+  notifications: "Read recent alerts and important system messages.",
+  settings: "Adjust preferences and configure your account.",
+};
+
+export default function ItemPage({ params }: { params: { id: string } }) {
+  const item = defaultNav.find((i) => i.id === params.id);
+  if (!item) return <p className="text-red-500">Page not found.</p>;
+
+  return (
+    <section className="space-y-4">
+      <header className={`${item.color} rounded px-4 py-3`}>
+        <h1 className="text-xl font-semibold">{item.label}</h1>
+      </header>
+      <p className="text-gray-700">{content[item.id] || "Demo content goes here."}</p>
+    </section>
+  );
+}

--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -1,15 +1,26 @@
 "use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useNav } from "../nav-context";
 
 export function SideNav() {
   const { nav } = useNav();
+  const path = usePathname();
   return (
-    <aside className="w-48 border-r p-4 space-y-2">
-      {nav.map((i) => (
-        <a key={i.id} href="#" className="block hover:underline">
-          {i.label}
-        </a>
-      ))}
+    <aside className="w-56 bg-gray-50 border-r h-screen p-4 space-y-1">
+      {nav.map((i) => {
+        const active = path === `/${i.id}`;
+        return (
+          <Link
+            key={i.id}
+            href={`/${i.id}`}
+            className={`flex items-center gap-3 px-3 py-2 rounded hover:bg-gray-200 ${active ? "bg-gray-200 font-medium" : ""}`}
+          >
+            <i.Icon className="w-5 h-5" />
+            <span>{i.label}</span>
+          </Link>
+        );
+      })}
     </aside>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,7 +31,7 @@ export default function Home() {
         rows={3}
         value={prompt}
         onChange={(e) => setPrompt(e.target.value)}
-        placeholder="e.g. 'Hide items 2‑10, put item 15 first'"
+        placeholder="e.g. 'Hide sales and move analytics first'"
       />
       <div className="flex gap-4">
         <button

--- a/lib/nav-items.ts
+++ b/lib/nav-items.ts
@@ -1,6 +1,77 @@
-export type NavItem = { id: string; label: string };
+import React from "react";
+export type IconProps = React.SVGProps<SVGSVGElement>;
+export type NavItem = {
+  id: string;
+  label: string;
+  Icon: (props: IconProps) => JSX.Element;
+  color: string;
+};
 
-export const defaultNav: NavItem[] = Array.from({ length: 15 }, (_, i) => ({
-  id: `item-${i + 1}`,
-  label: `Item ${i + 1}`,
-}));
+// Simple SVG icons inspired by Heroicons
+export const HomeIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 9.75L12 3l9 6.75" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 10.5V20h6v-6h3v6h6v-9.5" />
+  </svg>
+);
+
+export const ChartBarIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 3v18h18" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 17V9m4 8V5m4 8v-4" />
+  </svg>
+);
+
+export const CurrencyIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v18m-6-9h12" />
+  </svg>
+);
+
+export const UsersIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="9" cy="8" r="3" />
+    <circle cx="15" cy="8" r="3" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M2 21c0-3.5 5-6 7-6s7 2.5 7 6" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M17 15c2 0 5 1.5 5 4" />
+  </svg>
+);
+
+export const CubeIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 2l8 4v8l-8 4-8-4V6z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 22V12" />
+  </svg>
+);
+
+export const DocumentIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6 2h9l5 5v15H6z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M14 2v6h6" />
+  </svg>
+);
+
+export const BellIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 22a2 2 0 002-2H10a2 2 0 002 2z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M18 16V9a6 6 0 10-12 0v7L4 18h16l-2-2z" />
+  </svg>
+);
+
+export const CogIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="3" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M19.4 15a7.5 7.5 0 000-6l2.1-1.2-2-3.5-2.4 1a7.5 7.5 0 00-4.2-2.4l-.4-2.6h-4l-.4 2.6a7.5 7.5 0 00-4.2 2.4l-2.4-1-2 3.5 2.1 1.2a7.5 7.5 0 000 6L2.1 16.2l2 3.5 2.4-1a7.5 7.5 0 004.2 2.4l.4 2.6h4l.4-2.6a7.5 7.5 0 004.2-2.4l2.4 1 2-3.5-2.1-1.2z" />
+  </svg>
+);
+
+export const defaultNav: NavItem[] = [
+  { id: "dashboard", label: "Dashboard", Icon: HomeIcon, color: "bg-blue-600 text-white" },
+  { id: "analytics", label: "Analytics", Icon: ChartBarIcon, color: "bg-purple-600 text-white" },
+  { id: "sales", label: "Sales", Icon: CurrencyIcon, color: "bg-green-600 text-white" },
+  { id: "customers", label: "Customers", Icon: UsersIcon, color: "bg-yellow-500 text-white" },
+  { id: "products", label: "Products", Icon: CubeIcon, color: "bg-red-500 text-white" },
+  { id: "reports", label: "Reports", Icon: DocumentIcon, color: "bg-indigo-600 text-white" },
+  { id: "notifications", label: "Notifications", Icon: BellIcon, color: "bg-pink-600 text-white" },
+  { id: "settings", label: "Settings", Icon: CogIcon, color: "bg-gray-700 text-white" },
+];


### PR DESCRIPTION
## Summary
- add icons and nicer nav item names
- style SideNav links with active states
- create dummy pages for each nav item with colorful headers
- tweak placeholder text in the customisation example

## Testing
- `npm run build` *(fails: `next: not found`)*