### PR TITLE
Enable dark mode customization

### DIFF
--- a/app/api/customise/route.ts
+++ b/app/api/customise/route.ts
@@ -6,8 +6,8 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
 const system = `
 You are a UI assistant.
 Respond only with JSON.
-If the user request can be satisfied with hiding/reordering items, return:
-  { "order": ["item-…"], "hidden": ["item-…"] }
+If the user request can be satisfied with hiding/reordering items or changing the theme, return:
+  { "order": ["item-…"], "hidden": ["item-…"], "theme": { "mode": "light|dark", "foreground": "#hex", "background": "#hex" } }
 Else return:
   { "error": "Sorry, that's not supported yet. The team has been notified." }
 `;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { NavProvider } from "./nav-context";
 import { SideNav } from "./components/SideNav";
+import { ThemeProvider } from "./theme-context";
 
 export default function RootLayout({
   children,
@@ -10,10 +11,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="flex">
-        <NavProvider>
-          <SideNav />
-          <main className="flex-1 p-6">{children}</main>
-        </NavProvider>
+        <ThemeProvider>
+          <NavProvider>
+            <SideNav />
+            <main className="flex-1 p-6">{children}</main>
+          </NavProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/nav-context.tsx
+++ b/app/nav-context.tsx
@@ -3,8 +3,8 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { defaultNav, NavItem } from "@/lib/nav-items";
 
 interface NavState {
-  order: string[];
-  hidden: string[];
+  order?: string[];
+  hidden?: string[];
 }
 const STORAGE_KEY = "custom-nav";
 
@@ -29,13 +29,14 @@ export const NavProvider = ({ children }: { children: React.ReactNode }) => {
     );
 
   const update = (s: NavState) => {
-    setState(s);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+    const newState = { ...state, ...s };
+    setState(newState);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
   };
 
   const reset = () => {
     localStorage.removeItem(STORAGE_KEY);
-    setState({ order: [], hidden: [] });
+    setState({});
   };
 
   return <Ctx.Provider value={{ nav, update, reset }}>{children}</Ctx.Provider>;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 import { useState } from "react";
 import { useNav } from "./nav-context";
+import { useTheme } from "./theme-context";
 
 export default function Home() {
   const { update, reset } = useNav();
+  const { update: updateTheme, reset: resetTheme } = useTheme();
   const [prompt, setPrompt] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -19,7 +21,10 @@ export default function Home() {
     });
     const data = await res.json();
     if (data.error) setError(data.error);
-    else update(data);
+    else {
+      if (data.order || data.hidden) update(data);
+      if (data.theme) updateTheme(data.theme);
+    }
     setLoading(false);
     setPrompt("");
   }
@@ -41,7 +46,13 @@ export default function Home() {
         >
           {loading ? "Thinking…" : "Apply"}
         </button>
-        <button onClick={reset} className="underline text-sm">
+        <button
+          onClick={() => {
+            reset();
+            resetTheme();
+          }}
+          className="underline text-sm"
+        >
           Reset
         </button>
       </div>

--- a/app/theme-context.tsx
+++ b/app/theme-context.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+export interface ThemeState {
+  mode?: "light" | "dark";
+  foreground?: string;
+  background?: string;
+}
+
+const defaultTheme: ThemeState = {
+  mode: "light",
+  foreground: "#000000",
+  background: "#ffffff",
+};
+
+const STORAGE_KEY = "custom-theme";
+
+const Ctx = createContext<{
+  theme: ThemeState;
+  update: (t: ThemeState) => void;
+  reset: () => void;
+}>({ theme: defaultTheme, update: () => {}, reset: () => {} });
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [theme, setTheme] = useState<ThemeState>(() => {
+    if (typeof window === "undefined") return defaultTheme;
+    return { ...defaultTheme, ...JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}") };
+  });
+
+  const update = (t: ThemeState) => {
+    setTheme((prev) => ({ ...prev, ...t }));
+  };
+
+  const reset = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    setTheme(defaultTheme);
+  };
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(theme));
+    const root = document.documentElement;
+    if (theme.mode === "dark") root.classList.add("dark");
+    else root.classList.remove("dark");
+    if (theme.foreground)
+      root.style.setProperty("--foreground-rgb", hexToRgb(theme.foreground));
+    if (theme.background) {
+      const rgb = hexToRgb(theme.background);
+      root.style.setProperty("--background-start-rgb", rgb);
+      root.style.setProperty("--background-end-rgb", rgb);
+    }
+  }, [theme]);
+
+  return (
+    <Ctx.Provider value={{ theme, update, reset }}>{children}</Ctx.Provider>
+  );
+};
+
+export const useTheme = () => useContext(Ctx);
+
+function hexToRgb(hex: string) {
+  let h = hex.replace("#", "");
+  if (h.length === 3) h = h.split("").map((c) => c + c).join("");
+  const num = parseInt(h, 16);
+  const r = (num >> 16) & 255;
+  const g = (num >> 8) & 255;
+  const b = num & 255;
+  return `${r}, ${g}, ${b}`;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       backgroundImage: {


### PR DESCRIPTION
## Summary
- add new ThemeProvider and context
- allow choosing dark/light themes with custom colors
- integrate theme state in the UI and reset button
- instruct AI API to support theme changes
- use class-based dark mode in Tailwind

## Testing
- `npm run lint` *(fails: `next` not found)*