### PR TITLE
Add top bar and ThemeProvider

### DIFF
--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useState } from "react";
+import { defaultNav } from "@/lib/nav-items";
+import Link from "next/link";
+
+const iconPaths = [
+  <path key="1" d="M2 2h6v6H2z" />, // square
+  <circle key="2" cx="5" cy="5" r="3" />, // circle
+  <path key="3" d="M2 7l3-5 3 5H2z" />, // triangle
+  <path key="4" d="M5 2v6M2 5h6" />, // plus
+  <path key="5" d="M2 2l6 6M8 2L2 8" />, // cross
+];
+
+export function TopBar() {
+  const [open, setOpen] = useState(false);
+  const icons = defaultNav.slice(0, 5);
+  const menuItems = [
+    { label: "Dashboard", icon: "\uD83D\uDCC8", href: "#" },
+    { label: "Reports", icon: "\uD83D\uDCCA", href: "#" },
+    { label: "Contacts", icon: "\uD83D\uDC65", href: "#" },
+    { label: "Settings", icon: "\u2699\uFE0F", href: "#" },
+    { label: "Files", icon: "\uD83D\uDCC1", href: "#" },
+    { label: "Help", icon: "\u2753", href: "#" },
+    { label: "Customize this menu", icon: "\u2728", href: "/customize-menu" },
+  ];
+
+  return (
+    <div className="relative flex items-center justify-between bg-[#13B5EA] text-white px-4 py-2">
+      <div className="flex space-x-4">
+        {icons.map((i, idx) => (
+          <Link
+            key={i.id}
+            href="#"
+            title={i.label}
+            className="hover:underline"
+          >
+            <svg
+              viewBox="0 0 10 10"
+              className="w-5 h-5 fill-current"
+            >
+              {iconPaths[idx]}
+            </svg>
+          </Link>
+        ))}
+      </div>
+      <div className="relative">
+        <button
+          className="p-2"
+          onClick={() => setOpen((o) => !o)}
+          aria-label="Menu"
+        >
+          <svg className="w-6 h-6 fill-current" viewBox="0 0 20 20">
+            <path d="M2 4h16M2 10h16M2 16h16" />
+          </svg>
+        </button>
+        {open && (
+          <div className="absolute right-0 mt-2 w-48 bg-white text-black rounded shadow-lg z-10">
+            {menuItems.map((item) => (
+              <Link
+                key={item.label}
+                href={item.href}
+                className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100"
+                onClick={() => setOpen(false)}
+              >
+                <span>{item.icon}</span>
+                <span>{item.label}</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/customize-menu/page.tsx
+++ b/app/customize-menu/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+export default function CustomizeMenu() {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-bold">Customize This Menu</h1>
+      <p>This is a placeholder page where menu customization would go.</p>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import "./globals.css";
 import { NavProvider } from "./nav-context";
 import { SideNav } from "./components/SideNav";
+import { TopBar } from "./components/TopBar";
+import { ThemeProvider } from "./theme-provider";
 
 export default function RootLayout({
   children,
@@ -10,10 +12,15 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="flex">
-        <NavProvider>
-          <SideNav />
-          <main className="flex-1 p-6">{children}</main>
-        </NavProvider>
+        <ThemeProvider>
+          <NavProvider>
+            <SideNav />
+            <div className="flex-1 flex flex-col">
+              <TopBar />
+              <main className="flex-1 p-6">{children}</main>
+            </div>
+          </NavProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/theme-provider.tsx
+++ b/app/theme-provider.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+const ThemeCtx = createContext<{ theme: Theme; setTheme: (t: Theme) => void }>({
+  theme: "light",
+  setTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = (typeof window !== "undefined" && localStorage.getItem("theme")) as Theme | null;
+    if (stored) {
+      setThemeState(stored);
+      document.documentElement.classList.toggle("dark", stored === "dark");
+    }
+  }, []);
+
+  const setTheme = (t: Theme) => {
+    setThemeState(t);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("theme", t);
+      document.documentElement.classList.toggle("dark", t === "dark");
+    }
+  };
+
+  return (
+    <ThemeCtx.Provider value={{ theme, setTheme }}>{children}</ThemeCtx.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeCtx);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary
- add TopBar navigation bar with icons and hamburger menu
- wire TopBar into layout and wrap app with ThemeProvider
- set Tailwind dark mode via class
- include placeholder page to customize the menu

## Testing
- `npm run lint` *(fails: `next` not found)*